### PR TITLE
Fixed overwriting , fixed metadata fields, enable virus whole genomes.

### DIFF
--- a/app_specs/GeneTree.json
+++ b/app_specs/GeneTree.json
@@ -11,7 +11,7 @@
             "required": 1,
             "allow_multiple": 1,
             "filename": "string",
-            "type": ["aligned_dna_fasta", "aligned_protein_fasta", "feature_dna_fasta", "feature_protein_fasta", "feature_group"]
+            "type": ["aligned_dna_fasta", "aligned_protein_fasta", "feature_dna_fasta", "feature_protein_fasta", "feature_group", "genome_group"]
         },
         {
             "id": "trim_threshold",
@@ -50,6 +50,22 @@
             "desc": "Recipe used for FeatureTree analysis",
             "type": "enum",
             "enum": ["RAxML", "PhyML", "FastTree"]
+        },
+        {
+            "id": "feature_metadata_fields",
+            "label": "Gene Metadata Fields",
+            "required": 0,
+            "allow_multiple": 1,
+            "desc": "Fields to be retrieved for each gene.",
+            "type": "string"
+        },
+        {
+            "id": "genome_metadata_fields",
+            "label": "Genome Metadata Fields",
+            "required": 0,
+            "allow_multiple": 1,
+            "desc": "Fields to be retrieved for each genome.",
+            "type": "string"
         },
         {
             "id": "output_path",

--- a/lib/Phylo_Node.pm
+++ b/lib/Phylo_Node.pm
@@ -143,43 +143,14 @@ sub write_newick {
     return $retval
 }
 
-sub add_property {
-    my ($self, $ref, $val) = @_;
+sub add_phyloxml_property {
+    my ($self, $ref, $val, $data_type, $applies_to) = @_;
+    $data_type = "xsd:string" unless $data_type;
+    $applies_to = "node" unless $applies_to;
     $self->{_properties}{$ref} = $val;
-    print STDERR "Phylo_Node:add_single_property just added key=$ref, val=$self->{_properties}{$ref}\n" if $debug > 2;
-}
-
-sub add_single_property {
-    my ($self, $key, $val) = @_;
-    $self->{_properties}{$key} = $val;
-    print STDERR "Phylo_Node:add_single_property just added key=$key, val=$self->{_properties}{$key}\n" if $debug > 2;
-}
-
-sub add_bulk_properties_recursive {
-    my ($self, $metadata) = @_;
-
-	if (exists $self->{'_children'}) {
-		for my $child (@{$self->{'_children'}}) {
-			$child->add_bulk_properties_recursive($metadata);
-		}
-	}
-    if (exists $self->{'_name'} and $self->{'_name'}) {
-        #print STDERR "Look for $self->{'_name'} in $metadata: " if $debug;
-        #print STDERR join(', ', keys(%{$metadata})), "\n" if $debug;
-        my $node_name = $self->{'_name'};
-        if (exists $metadata->{$node_name}) {
-            print STDERR "Found $node_name in metadata, now add key-values.\n" if $debug > 2;
-            #$self->{properties} = ();
-            for my $key (keys %{$metadata->{$node_name}}) {
-                my $val = $metadata->{$node_name}{$key};
-                print STDERR "  bp  $key" if $debug > 2;
-                print STDERR " $val\n" if $debug > 2;
-                $key = "$metadata->{namespace}:$key" if (exists $metadata->{namespace});
-                $self->{_properties}{$key} = $val;
-                print STDERR "  np  $key $self->{_properties}{$key}\n" if $debug > 2;
-            }
-        }
-    }
+    $self->{_property_applies_to}{$ref} = $applies_to;
+    $self->{_property_datatype}{$ref} = $data_type;
+    print STDERR "Phylo_Node:add_phyloxml_property just added key=$ref, val=$self->{_properties}{$ref}\n" if $debug > 0;
 }
 
 sub write_phyloXML {
@@ -198,10 +169,8 @@ sub write_phyloXML {
     if (exists $self->{_properties}) {
         print STDERR "Properties found: refs = ", join(",", keys %{$self->{_properties}}), "\n" if $debug > 2;
         for my $ref (sort keys %{$self->{_properties}}) {
-            my $applies_to = "node";
-            $applies_to = $self->{_tree}{_property_applies_to}{$ref} if $self->{_tree}{_property_applies_to}{$ref};
-            my $datatype = "xsd:string";
-            $datatype = $self->{_tree}{_property_datatype}{$ref} if $self->{_tree}{_property_datatype}{$ref};
+            my $applies_to = $self->{_property_applies_to}{$ref};
+            my $datatype = $self->{_property_datatype}{$ref};
             $retval .= $indent . " <property ref=\"$ref\" datatype=\"$datatype\" applies_to=\"$applies_to\">";
             $retval .= $self->{_properties}{$ref} . "</property>\n";
         }

--- a/service-scripts/App-GeneTree.pl
+++ b/service-scripts/App-GeneTree.pl
@@ -21,6 +21,8 @@ our $global_ws;
 our $global_token;
 
 our $shock_cutoff = 10_000;
+my $max_genome_length = 100_000; #most/all single-sequence viruses are less than this
+my @original_sequence_ids; # list of items requested, can be different from those actually obtained
 
 our $debug = 0;
 $debug = $ENV{"GeneTreeDebug"} if exists $ENV{"GeneTreeDebug"};
@@ -129,8 +131,9 @@ sub write_report {
 }
 
 sub retrieve_sequence_data {
-    my ($app, $params, $api, $tmpdir) = @_;
+    my ($app, $params, $api,  $feature_metadata_fields, $genome_metadata_fields) = @_;
     my ($step_comments, $step_info) = start_step("Gather Sequence Data");
+    my @seq_items; # array of hash refs, one for each dataset
     my $comment;
     my ($aligned_state, $any_in_memory) = (0, 0);
     $aligned_state = (scalar(@{$params->{sequences}}) == 1 and $params->{sequences}->[0]->{type} =~ /Aligned/i); 
@@ -140,73 +143,156 @@ sub retrieve_sequence_data {
     for my $sequence_item (@{$params->{sequences}}) {
         print STDERR "data item: $sequence_item->{type}, $sequence_item->{filename}\n";
         push @{$step_comments}, "reading $sequence_item->{type} $sequence_item->{filename}";
+        my %seq_data; # data about this set of sequences
+        push @seq_items, \%seq_data;
         my $num_seqs = 0;
+        $seq_data{"type"}=$sequence_item->{type};
+        $seq_data{"is_aligned"}=0;
         if ($sequence_item->{type} =~ /FASTA/i) {
             # then it is one of the fasta formats in the workspace
             my $local_file = $sequence_item->{filename};
             $local_file =~ s/.*\///;
-            print STDERR "About to copy file $sequence_item->{filename} to $tmpdir/$local_file\n";
-            $app->workspace->download_file($sequence_item->{filename}, "$tmpdir/$local_file", 1, $global_token);
-            $sequence_item->{local_file} = $local_file;
-            open F, "$tmpdir/$local_file";
+            print STDERR "About to copy file $sequence_item->{filename} to $local_file\n";
+            $app->workspace->download_file($sequence_item->{filename}, $local_file, 1, $global_token);
+            open F, $local_file;
             while (<F>) {
-                $num_seqs++ if /^>/ }
-            close F
+                $num_seqs++ if /^>(\S+)/;
+                push @original_sequence_ids, $1;
+            }
+            close F;
+            $seq_data{"name"}=$local_file;
+            $seq_data{"type"}="local_file"; # makes it easier to recognize which ones are already written to files
+            $seq_data{"num_seqs"}=$num_seqs;
+            $seq_data{"is_aligned"} = $sequence_item->{type} =~ /ALIGNED/i; # could be aligned_dna_fasta or aligned_protein_fasta
         }
         elsif ($sequence_item->{type} eq "feature_group") {
             # need to get feature sequences from database 
-            $any_in_memory = 1;
             my $feature_group = $sequence_item->{filename};
+            $seq_data{"name"} = $feature_group;
+            $seq_data{"type"}="feature_group"; 
             $comment = "retrieving sequences for feature group $feature_group";
             print STDERR $comment, "\n";
             push @{$step_comments}, $comment;
-            my $seq_list;
-            if ($params->{alphabet} eq 'DNA') {
-                $seq_list = $api->retrieve_nucleotide_sequences_from_feature_group($feature_group, ['patric_id', 'product', 'genome_id']);
-            } else {
-                $seq_list = $api->retrieve_protein_sequences_from_feature_group($feature_group, ['patric_id', 'product', 'genome_id']);
+            if ($debug) {
+                my $feature_ids = $api->retrieve_patricids_from_feature_group($feature_group);
+                print STDERR "\nfeature_ids = @$feature_ids\n";
+                print STDERR "number feature_ids is ", scalar @$feature_ids, "\n";
             }
-            $comment = "number of elements = " . scalar(@$seq_list);
+
+            my @copy_of_feature_metadata_fields = (@$feature_metadata_fields); # use copy because api methods will over-write it
+            my $seq_list;
+            my $na_or_aa = ('aa', 'na')[$params->{alphabet} eq 'DNA']; 
+            $seq_list = $api->retrieve_sequences_from_feature_group($feature_group, $na_or_aa, \@copy_of_feature_metadata_fields);
+            #if ($params->{alphabet} eq 'DNA') {
+            #    $seq_list = $api->retrieve_nucleotide_sequences_from_feature_group($feature_group, \@copy_of_feature_metadata_fields);
+            #} else {
+            #    $seq_list = $api->retrieve_protein_sequences_from_feature_group($feature_group, \@copy_of_feature_metadata_fields);
+            #}
+            if ($debug) {
+                print STDERR "retreive_sequences_from_feature_group return is $seq_list\n"; 
+                print STDERR "length is ", scalar @$seq_list, "\n"; 
+                print STDERR "First element = $seq_list->[0]\n";
+                for my $key (sort keys %{$seq_list->[0]}) {
+                    print STDERR "    \t$key\t$seq_list->[0]->{$key}\n";
+                }
+            }
+            $seq_data{"seq_list"} = $seq_list;
+            $num_seqs = scalar @$seq_list;
+            $seq_data{"type"}='feature_group';
+            $seq_data{"num_seqs"}= $num_seqs;
+            for my $record (@$seq_list) {
+                push @original_sequence_ids, $record->{patric_id};
+            }
+            $comment = "number of elements = $num_seqs";
             push @{$step_comments}, $comment;
             print STDERR $comment, "\n";
-            $sequence_item->{sequences} = {};
-            $params->{metadata} = {} unless $params->{metadata};
-            print STDERR "params->metadata = $params->{metadata}\n";
-            for my $seq_record (@$seq_list) {
-                my $seq_id;
-                if (exists $seq_record->{'patric_id'}) { 
-                    $seq_id = $seq_record->{'patric_id'};
-                }
-                else {
-                    $seq_id = $seq_record->{'feature_id'}
-                }
-                $sequence_item->{sequences}{$seq_id} = $seq_record->{'sequence'};
-                $params->{metadata}{$seq_id} = {};
-                for my $key (keys %{$seq_record}) {
-                    print STDERR "key=$key ";
-                    unless ($key eq 'sequence') {
-                        #print STDERR "params->metadata->$seq_id = $params->{metadata}{$seq_id}\n";
-                        $params->{metadata}{$seq_id}{$key} = $seq_record->{$key};
-                    }
+        }
+        elsif ($sequence_item->{type} eq "genome_group") {
+            if (scalar @{$params->{sequences}} > 1) {
+                print STDERR "Genome group $sequence_item->{filename} combined with other sequence inputs. This case is not handled yet. Exiting.\n";
+                `cd ..`; # to allow temp directory to be deleted
+                exit(1);
+            }
+            $feature_metadata_fields = \(); # we will not be using these
+            # need to check genomes are:
+            #   1) single-sequence (not multiple contigs)
+            #   2) short enough (below threshold length specified in json parameters?)
+            $comment = "retrieving sequences for genome group $sequence_item->{filename}\n";
+            print STDERR "$comment\n";
+            push @{$step_comments}, $comment;
+            my $genome_ids = $api->retrieve_patric_ids_from_genome_group($sequence_item->{filename});
+            for my $id (@$genome_ids) {
+                print STDERR "$id\n";
+            }
+            my @copy_of_genome_metadata_fields = (@$genome_metadata_fields);
+            push @copy_of_genome_metadata_fields, ('genome_id', 'contigs', 'superkingdom', 'genome_length');
+            my @genome_metadata = $api->retrieve_genome_metadata($genome_ids, \@copy_of_genome_metadata_fields);
+            print STDERR "retrieve_genome_metadata:\n";
+            print STDERR join("\t", ('genome_id', 'contigs', 'superkingdom', 'genome_length')), "\n";
+            for my $info (@genome_metadata) {
+                for my $key ('genome_id', 'contigs', 'superkingdom', 'genome_length') {
+                    #for my $key (sort(keys %$info)) {
+                    print STDERR "$info->{$key}\t";
                 }
                 print STDERR "\n";
+                if ($info->{'genome_length'} > $max_genome_length) {
+                    print STDERR "Problem: length of genome $info->{'genome_id'} exceeds $max_genome_length ($info->{'genome_length'}).\nExiting.\n";
+                    `cd ..`;
+                    exit(1);
+                }
+                if ($info->{'superkingdom'} ne 'Viruses') {
+                    print STDERR "Problem: superkingdom of genome $info->{'genome_id'} is not 'Viruses' ($info->{'superkingdom'}).\nExiting.\n";
+                    `cd ..`;
+                    exit(1);
+                }
+                if ($info->{'contigs'} > 1) {
+                    print STDERR "Problem: genome $info->{'genome_id'} has multiple contigs ($info->{'contigs'}).\nExiting.\n";
+                    `cd ..`;
+                    exit(1);
+                }
             }
-            $num_seqs = scalar keys %{$sequence_item->{sequences}};
+            print STDERR "All genomes are viruses, all have a single sequence, all are under $max_genome_length bases.\n";
+            push @original_sequence_ids, @$genome_ids;
+            $num_seqs = scalar @$genome_ids;
+            my $fasta_file = $sequence_item->{filename};
+            $fasta_file =~ s/.*\///; # remove everything upto and including last slash
+            $fasta_file =~ tr/ /_/;  # replace any blank spaces
+            $fasta_file .= ".fasta";
+            my $genome_seqs = $api->retrieve_contigs_in_genomes_to_temp($genome_ids);
+            #print STDERR "retrieve_contigs_in_genomes_to_temp returned $genome_seqs\n";
+            print STDERR "saving sequences to $fasta_file\n";
+            open OUT, ">$fasta_file";
+            open IN, $genome_seqs;
+            while (<IN>) {
+                s/>accn\|(\d+\.\d+).con.*/>$1/; # replace definition line with simple genome_id
+                print OUT $_;
+            }
+            unlink($genome_seqs);
+            close OUT;
+            
+            $seq_data{"name"}=$fasta_file;
+            $seq_data{"type"}="local_file"; # makes it easier to recognize which ones are already written to files
+            $seq_data{"num_seqs"}=$num_seqs;
+            $seq_data{"genome_metadata"} = \@genome_metadata;
+            $comment = "number of elements = $num_seqs";
+            push @{$step_comments}, $comment;
+            print STDERR $comment, "\n";
         }
         elsif ($sequence_item->{type} eq "feature_ids") {
             # need to get feature sequences from database 
-            $any_in_memory = 1;
             $comment = "retrieving sequences for feature ids";
+            $comment .= ", this functionality not implemented yet";
             push @{$step_comments}, $comment;
             my $feature_ids = $sequence_item->{sequences};
-            print STDERR "\tfeature_ids = ", join(", ", @$feature_ids), "\n" if $debug;
-            if ($params->{alphabet} eq 'DNA') {
-                $sequence_item->{sequences} = $api->retrieve_nucleotide_feature_sequence($feature_ids);
-            }
-            else {
-                $sequence_item->{sequences} = $api->retrieve_protein_feature_sequence($feature_ids);
-            }
-            $num_seqs = scalar keys %{$sequence_item->{sequences}};
+            exit(1);
+            #print STDERR "\tfeature_ids = ", join(", ", @$feature_ids), "\n" if $debug;
+            #if ($params->{alphabet} eq 'DNA') {
+            #    $sequence_item->{sequences} = $api->retrieve_nucleotide_feature_sequence($feature_ids);
+            #}
+            #else {
+            #    $sequence_item->{sequences} = $api->retrieve_protein_feature_sequence($feature_ids);
+            #}
+            #$num_seqs = scalar keys %{$sequence_item->{sequences}};
         }
         $comment = "number of sequences retrieved: $num_seqs";
         push @{$step_comments}, $comment;
@@ -222,99 +308,115 @@ sub retrieve_sequence_data {
         print STDERR "$comment\n";
     }
     end_step("Gather Sequence Data");
-    return ($aligned_state, $any_in_memory);
+    return \@seq_items;
 }
 
-sub merge_sequence_sets {
-    my ($params, $tmpdir) = @_;
+sub write_sequences_to_file {
+    my ($seq_set, $unaligned_file) = @_;
+    open F, ">$unaligned_file";
+    my $id_field = "";
+    if ($seq_set->{type} eq "feature_group") {
+        $id_field = "patric_id";
+    }
+    elsif ($seq_set->{type} eq "genome_group") {
+        $id_field = "genome_id";
+    }
+    else {
+        print STDERR "warning: write_sequences_to_file called on a seq_set that is neither feature_group nor genome_group\n";
+        print STDERR "name = $seq_set->{name}, type = $seq_set->{type}\n";
+        exit(1);
+    }
+    for my $seq_item (@{$seq_set->{seq_list}}) {
+        print F ">$seq_item->{$id_field}\n$seq_item->{sequence}\n";
+    }
+    close F;
+}
+
+sub merge_sequence_sets_to_file {
+    my ($seq_items, $output_file) = @_;
     my ($step_comments, $step_info) = start_step("Merge Sequence Sets");
-    my $comment = "merge_sequence_sets: $params, $tmpdir";
-    #push @{$step_comments}, $comment;
+    my $comment = "merge_sequence_sets_to_file: $seq_items, $output_file";
+    print STDERR $comment, "\n" if $debug;
+    push @{$step_comments}, $comment;
     print STDERR "$comment\n";
     # goal is to end up with all sequences written to a single unaligned FASTA file
     # only needed when multiple input sequence sets are passed
-    for my $seq_item (@{$params->{sequences}}) {
-        if (exists $seq_item->{local_file}) {
-            $comment = "reads sequences from $seq_item->{local_file}";
+    my @seq_list;
+    for my $seq_set (@$seq_items) {
+        if ($seq_set->{type} eq 'local_file') {
+            $comment = "read sequences from $seq_set->{name}";
             #push @{$step_comments}, $comment;
             print STDERR "$comment\n";
-            open INDATA, "$tmpdir/$seq_item->{local_file}";
+            open INDATA, $seq_set->{name};
             my $seqid = '';
-            $seq_item->{sequences} = ();
+            my $sequence = '';
+            my $num_seqs = 0;
             while (<INDATA>) {
                 if (/^>(\S+)/) {
-                    $seqid = $1;
-                    if (exists $seq_item->{sequences}->{$seqid}) { # fix up non-unique seq identifier
-                        $comment = "got non-unique sequence ID $seqid";
-                        my $suffix = 2;
-                        while (exists $seq_item->{sequences}->{$seqid . "_$suffix"}) {
-                            $suffix++
-                        }
-                        $seqid = $seqid . "_$suffix";
-                        $comment .= ", appending $suffix";
-                        push @{$step_comments}, $comment;
+                    if ($seqid) {
+                        push @seq_list, [$seqid, $sequence];
+                        $num_seqs++;
                     }
+                    $seqid = $1;
+                    $sequence = '';
                 }
                 else {
                     chomp;
-                    $seq_item->{sequences}->{$seqid} .= $_
+                    tr/-//d; # strip out gap characters;
+                    $sequence .= $_;
                 }
             }
-            $comment = "found " . scalar keys %{$seq_item->{sequences}}, " sequences in $seq_item->{local_file}.";
+            if ($seqid) {
+                push @seq_list, [$seqid, $sequence];
+                $num_seqs++;
+            }
+            $comment = "found $num_seqs sequences in $seq_set->{name}.";
+            #push @{$step_comments}, $comment;
+            print STDERR "$comment\n";
+        }
+        elsif ($seq_set->{type} eq 'feature_group') { #handle case of feature_group (sequences in memory)
+            my $num_seqs = 0;
+            for my $seq_item (@{$seq_set->{seq_list}}) {
+                #print "keys to seq_list item as hash: " . join("\n", keys %$seq_item);
+                $num_seqs++;
+                push @seq_list, [$seq_item->{patric_id}, $seq_item->{sequence}];
+            }
+            $comment = "found $num_seqs sequences in $seq_set->{name}.";
             #push @{$step_comments}, $comment;
             print STDERR "$comment\n";
         }
     }
-    $comment = "merging all sequences";
-    #push @{$step_comments}, $comment;
-    print STDERR "$comment\n";
-    my %all_seqs = ();
-    for my $seq_item (@{$params->{sequences}}) {
-        $comment = "visiting $seq_item->{filename}";
-        #push @{$step_comments}, $comment;
-        print STDERR "$comment\n";
-        # each item should now have a hash of sequences
-        for my $seqid (keys %{$seq_item->{sequences}}) {
-            my $orig_seqid = $seqid;
-            if (exists $all_seqs{$seqid}) {
-                $comment = "got non-unique sequence ID $seqid";
+
+    open OUTDATA, ">$output_file";
+    my %seq_hash;
+    my $numseqs = 0;
+    for my $seq_item (@seq_list) {
+        my ($seqid, $sequence) = @$seq_item;
+        if (exists $seq_hash{$seqid}) { # fix up non-unique seq identifier
+            $comment = "got repeated sequence ID $seqid";
+            if ($sequence eq $seq_hash{$seqid}) {
+                $comment .= " and sequences are identical: dropping second occurrence.";
+                continue;
+            }
+            else {
                 my $suffix = 2;
-                while (exists $all_seqs{$seqid . "_$suffix"}) {
+                while (exists $seq_item->{sequences}->{$seqid . "_$suffix"}) {
                     $suffix++
                 }
                 $seqid = $seqid . "_$suffix";
-                $comment = ", appending $suffix";
-                push @{$step_comments}, $comment;
+                $comment .= " but sequences differ, renaming to $seqid.";
             }
-            $all_seqs{$seqid} = $seq_item->{sequences}->{$orig_seqid}
+            push @{$step_comments}, $comment;
         }
+        print OUTDATA ">$seqid\n$sequence\n";
+        $seq_hash{$seqid} = $sequence;
+        $numseqs++;
     }
-    if ($debug) {
-        for my $seqid (keys %all_seqs) {
-            print STDERR "debug: $seqid\n$all_seqs{$seqid}\n";
-        }
-    }
-    my %seq_item = ();
-    $seq_item{sequences} = \%all_seqs;
-    $params->{sequences} = [\%seq_item]; # now only one entry in array, includes all sequences
-    $comment = "total number of sequences is ". scalar keys %{$params->{sequences}->[0]->{sequences}};
+    close OUTDATA;
+    $comment = "$numseqs sequences written to $output_file";
     push @{$step_comments}, $comment;
     print STDERR "$comment\n";
     end_step("Merge Sequence Sets");
-    return \%all_seqs;
-}
-
-sub write_unaligned_sequences_to_file {
-    my ($sequences, $outfile) = @_; 
-    print STDERR "Write sequences to $outfile\n";
-    open F, ">$outfile";
-    for my $seq_id (sort keys %{$sequences}) {
-        my $seq = $sequences->{$seq_id};
-        $seq =~ tr/-//d;
-        $seq =~ tr/\s//d;
-        print F ">$seq_id\n$seq\n";
-    }
-    close F;
 }
 
 sub build_tree {
@@ -329,147 +431,213 @@ sub build_tree {
     my $tmpdir = File::Temp->newdir( "/tmp/GeneTree_XXXXX", CLEANUP => !$debug );
     system("chmod", "755", "$tmpdir");
     print STDERR "created temp dir: $tmpdir, cleanup = ", !$debug, "\n";
+    my $original_wd = getcwd();
+    chdir($tmpdir); # do all work in temporary directory
    
-    my ($aligned_state, $any_in_memory) = retrieve_sequence_data($app, $params, $api, $tmpdir);
+    my @feature_metadata_fields = ("product", "accession");
+    if (exists $params->{feature_metadata_fields}) {
+        @feature_metadata_fields = @{$params->{feature_metadata_fields}};
+    }
+    #ensure that patric_id and genome_id are retrieved
+    push @feature_metadata_fields, "patric_id" unless grep(/patric_id/, @feature_metadata_fields);
+    push @feature_metadata_fields, "genome_id" unless grep(/genome_id/, @feature_metadata_fields);
+
+    my @genome_metadata_fields = (
+        "species", "strain", "geographic_group", "isolation_country", "host_group", "host_common_name", "collection_year", "subtype", "lineage", "clade");
+
+    if (exists $params->{genome_metadata_fields}) {
+        @genome_metadata_fields = @{$params->{genome_metadata_fields}};
+    }
+    ##!!!*** folowing line is for debugging
+    #@genome_metadata_fields = ('species','host_name','geographic_location','collection_date');
+
+    my $seq_items = retrieve_sequence_data($app, $params, $api, \@feature_metadata_fields, \@genome_metadata_fields);
     my $unaligned_file = undef;
     my $aligned_file = undef;
-    if (scalar @{$params->{sequences}} > 1) {
-        #print STDERR "About to merge sequences, tmpdir=$tmpdir\n";
-        merge_sequence_sets($params, $tmpdir);
-        $any_in_memory = 1;
+    if (scalar @$seq_items == 1) {
+        if ($seq_items->[0]->{type} eq 'local_file') {
+            if ($seq_items->[0]->{is_aligned}) {
+                $aligned_file = $seq_items->[0]->{name};
+            }
+            else {
+                $unaligned_file = $seq_items->[0]->{name};
+            }
+        }
+        elsif ($seq_items->[0]->{type} eq 'feature_group' | $seq_items->[0]->{type} eq 'genome_group') {
+            $unaligned_file = "$params->{output_file}_unaligned.fa";
+            write_sequences_to_file($seq_items->[0], $unaligned_file);
+        }
     }
-    if ($any_in_memory) {
-        $unaligned_file = "$tmpdir/$params->{output_file}_unaligned.fa";
-        write_unaligned_sequences_to_file($params->{sequences}[0]->{sequences}, $unaligned_file);
+    else {
+        $unaligned_file = "$params->{output_file}_unaligned.fa";
+        merge_sequence_sets_to_file($seq_items, $unaligned_file);
     }
-    elsif (!$aligned_state) {
-        $unaligned_file = $params->{sequences}[0]->{local_file}
+    my $num_seqs = 0;
+    for my $seq_set (@$seq_items) {
+        $num_seqs += $seq_set->{num_seqs};
+    }
+    if ($num_seqs < 4) { #need at least 4 seuqences to build a tree
+        print STDERR "After retrieval, number of sequences is $num_seqs, less than 4. Cannot build a tree.\n";
+        #die "Too few sequences."
+        exit(1);
     }
     if ($unaligned_file) {
         $aligned_file = $unaligned_file;
         $aligned_file =~ s/\..{1,6}$//;
         $aligned_file =~ s/unaligned/aligned/;
         $aligned_file .= ".afa";
-        run_muscle($unaligned_file, $aligned_file, $tmpdir);
+        #run_muscle($unaligned_file, $aligned_file);
+        run_mafft($unaligned_file, $aligned_file);
+        if ($params->{trim_threshold} or $params->{gap_threshold})
+        {
+            my $trimmed_aligned_file = $aligned_file;
+            $trimmed_aligned_file =~ s/.afa//;
+            $trimmed_aligned_file .= "_trimmed.afa";
+            trim_alignment($aligned_file, $trimmed_aligned_file, $params->{trim_threshold}, $params->{gap_threshold});
+            print STDERR "trimmed aligned file written to $trimmed_aligned_file\n" if $debug;
+            $aligned_file = $trimmed_aligned_file;
+        }
     }
-    else { # if there was only one sequence source, and it was aligned and a file, leave it alone
-        $aligned_file = "$tmpdir/$params->{sequences}[0]->{local_file}"
+    open F, $aligned_file;
+    $num_seqs = 0;
+    my %altered_name;
+    my $alignment_text;
+    my @seqid_list;
+    while (<F>) { # count sequences and replace any illegal characters in sequence IDs (not allowed by newick standard)
+        if (/^>(\S+)/) {
+            $num_seqs++;
+            my $seq_id = $1;
+            if ($seq_id =~ /[[]():]/) {
+                my $orig = $seq_id;
+                $seq_id =~ tr/:()[]/_____/; # replace any bad characters with underscores
+                $altered_name{$seq_id} = $orig;
+                print STDERR "replacing identifier $orig with $seq_id\n";
+            }
+            push @seqid_list, $seq_id;
+            $alignment_text .= ">$seq_id\n";
+        }
+        else {
+            $alignment_text .= $_;
+        }
     }
-    my $alignment = new Sequence_Alignment($aligned_file);
-    my $seq_ids = $alignment->get_ids();
-    print STDERR "num seqs: ", scalar @{$seq_ids}, "\n";
-    print STDERR "seq ids: ", join(", ", @{$seq_ids}), "\n" if $debug;
-    #if ($debug) {
-    #    push @outputs, [$jdesc, 'txt']
-    #}
-
-    if ($params->{trim_threshold} or $params->{gap_threshold})
-    {
-        trim_alignment($alignment, $params, $tmpdir);
-        $aligned_file =~ s/.afa//;
-        $aligned_file .= "_trimmed.afa";
-        $alignment->write_fasta($aligned_file);
-        print STDERR "trimmed aligned file written to $aligned_file\n" if $debug;
-        $seq_ids = $alignment->get_ids();
-        print STDERR "num seqs: ", scalar @{$seq_ids}, "\n";
+    if ($num_seqs < 4) { #need at least 4 seuqences to build a tree
+        print STDERR "After looking at aligned seqs, number of sequences is $num_seqs, less than 4. Cannot build a tree.\n";
+        exit(1);
+    }
+    if (scalar keys %altered_name) {  # if sequence IDs needed to be altered, write altered alignment
+        my $altered_aligned_file = $aligned_file;
+        $altered_aligned_file =~ s/\..{3,6}$//; #remove extension
+        $altered_aligned_file .= "_altered_ids.afa";
+        $aligned_file = $altered_aligned_file;
+        write_file($aligned_file, $alignment_text);
+        #open F, ">$aligned_file";
+        #print F $alignment_text;
+        #close F;
     }
     my $alphabet = $params->{alphabet};
     push @outputs, [$aligned_file, "aligned_${alphabet}_fasta"];
     run("echo $tmpdir && ls -ltr $tmpdir");
-    
-    my $num_seqs = $alignment->get_ntaxa();
-    my $tree_graphic_file = undef;
 
-    if ($num_seqs >= 4) { #need at least 4 seuqences to build a tree
-        my $model = "LG"; # default for protein
-        if ($params->{substitution_model}) {
-            $model = $params->{substitution_model}
+    my $model = "LG"; # default for protein
+    if ($params->{substitution_model}) {
+        $model = $params->{substitution_model}
+    }
+    elsif ($params->{alphabet} =~ /DNA/i) {
+        $model = "GTR"
+    }
+    my $output_name = $params->{output_file};
+    my $recipe = "raxml"; #default
+    if (defined $params->{recipe} and $params->{recipe}) {
+        $recipe = lc($params->{recipe})
+    }
+    print STDERR "About to call tree program $recipe\n";
+    my @tree_outputs;
+    if ($recipe eq 'raxml') {
+        @tree_outputs = run_raxml($aligned_file, $alphabet, $model, $output_name);
+    } elsif ($recipe eq 'phyml') {
+        my $alignment = new Sequence_Alignment($aligned_file);
+        my $phylip_file = $aligned_file;
+        $phylip_file =~ s/\..{2,4}$//;
+        $phylip_file .= ".phy";
+        $alignment->write_phylip($phylip_file);
+        @tree_outputs = run_phyml($phylip_file, $alphabet, $model, $output_name);
+    } elsif (lc($recipe) eq 'fasttree') {
+        #$alignment->write_fasta($aligned_file);
+        @tree_outputs = run_fasttree($aligned_file, $alphabet, $model, $output_name);
+    } else {
+        die "Unrecognized recipe: $recipe \n";
+    }
+    push @outputs, @tree_outputs;
+    # optionally re-write newick file with original sequence IDs if any were altered
+    # not sure we want to do that as it could screw up downstream use of newick data i
+    # (ideally, bad characters should be escaped, but does raxml know about escaped characters?)
+    # generate tree graphic using figtree
+    my $tree_file = undef;
+    my $tree_graphic = undef;
+    for my $output (@outputs) {
+        my($ofile, $type) = @$output;
+        if ($type eq 'nwk') {
+            $tree_file = $ofile;
+            $tree_graphic = generate_tree_graphic($tree_file, $num_seqs);
+            push @outputs, $tree_graphic;
         }
-        elsif ($params->{protein_model}) {
-            $model = $params->{protein_model}
-        }
-        elsif ($params->{alphabet} =~ /DNA/i) {
-            $model = "GTR"
-        }
-        my $output_name = $params->{output_file};
-        my $recipe = "raxml"; #default
-        if (defined $params->{recipe} and $params->{recipe}) {
-            $recipe = lc($params->{recipe})
-        }
-        print STDERR "About to call tree program $recipe\n";
-        if ($recipe eq 'raxml') {
-            my $bad_chars = $alignment->write_fasta_for_raxml("$tmpdir/alignment_for_raxml.fa");
-            my @tree_outputs = run_raxml("$tmpdir/alignment_for_raxml.fa", $alphabet, $model, $output_name, $tmpdir);
-            if ($bad_chars) {
-                for my $item (@outputs) {
-                    if ($item->[1] eq 'nwk') {
-                        my $newick_file_name = "$tmpdir/$item->[0]";
-                        open F, "+<", $newick_file_name;
-                        my $raxml_newick = "";
-                        while (<F>) {
-                            chomp;
-                            $raxml_newick .= $_
-                        }
-                        my $restored_newick = $alignment->restore_original_ids_in_raxml_tree($raxml_newick);
-                        seek F, 0, 0;
-                        truncate F, 0;
-                        print F $restored_newick;
-                        close F
-                    }
-
-                    # look for nkw file, revert any changes made to seq_ids for raxml
+    }
+    if ($tree_file)
+    {  
+        my $metadata = gather_metadata($seq_items, \@seqid_list, \%altered_name, \@feature_metadata_fields, \@genome_metadata_fields); 
+        print "gather_metadata: hash size = " . scalar(keys %$metadata). "\n" if $debug;
+        my $tree = new Phylo_Tree($tree_file);
+        if ($metadata and scalar keys %$metadata) {
+            my $metadata_file = "$params->{output_file}_metadata.txt";
+            open F, ">$metadata_file";
+            my @header_fields = ();
+            for my $field (keys %$metadata) {
+                push @header_fields, $field unless $field eq 'patric_id'; # dont put patric_id in header fields
+            }
+            if ($debug) {
+                print F "header fields: ", join("\t", "SeqId", @header_fields) . "\n";
+                print STDERR "seqid_list: ", join(' ', @seqid_list), "\n";
+                for my $field (@header_fields) {
+                    print STDERR "For md $field: seq keys = ", join(" ", sort keys %{$metadata->{$field}}), "\n";
                 }
             }
+            for my $id (@seqid_list) {
+                print F $id;
+                for my $field (@header_fields) {
+                    my $val = "na";
+                    $val = $metadata->{$field}{$id} if exists $metadata->{$field}{$id};
+                    print F "\t$val";
+                }
+                print F "\n";
+            }
+            close F;
+            push @outputs, [$metadata_file, "tsv"];
+            
+            for my $field (@feature_metadata_fields, @genome_metadata_fields) {
+                print STDERR "add metadata field: $field\n";
+                $tree->add_tip_phyloxml_properties($metadata->{$field}, $field, "BVBRC");
+            }
+        }
+        my ($step_comments, $step_info) = start_step("Write PhyloXML");
+        my $phyloxml_data = $tree->write_phyloXML();
+        my $phyloxml_file = "$params->{output_file}.xml";
+        write_file($phyloxml_file, $phyloxml_data);
+        push @outputs, [$phyloxml_file, "phyloxml"];
+        end_step("Write PhyloXML");
 
-            push @outputs, @tree_outputs;
-        } elsif ($recipe eq 'phyml') {
-            $aligned_file =~ s/\.msa/.phy/;
-            $alignment->write_phylip($aligned_file);
-            my @tree_outputs = run_phyml($aligned_file, $alphabet, $model, $output_name, $tmpdir);
-            push @outputs, @tree_outputs;
-        } elsif (lc($recipe) eq 'fasttree') {
-            #$alignment->write_fasta($aligned_file);
-            my @tree_outputs = run_fasttree($aligned_file, $alphabet, $model, $output_name, $tmpdir);
-            push @outputs, @tree_outputs;
-        } else {
-            die "Unrecognized recipe: $recipe \n";
+        my @relabel_fields = ();
+        for my $field ("species", "product") {
+            push @relabel_fields, $field if (exists $metadata->{$field});
         }
-        # generate tree graphic using figtree
-        my $tree_file = undef;
-        for my $output (@outputs) {
-            my($ofile, $type) = @$output;
-            if ($type eq 'nwk') {
-                $tree_file = $ofile;
-                $tree_graphic_file .= generate_tree_graphic($tree_file, $num_seqs, $tmpdir);
-            }
-        }
-        if ($tree_file)
-        {  
-            my $seq_ids_ar = $alignment->get_ids();
-            my $feature_fields = ['patric_id', 'genome_id', 'product'];
-            my $genome_fields = ['genome_id','species','host_name','geographic_location','collection_date'];
-            my $metadata_tsv = gather_metadata($params->{metadata}, $seq_ids_ar, $feature_fields, $genome_fields); 
-            print "gather_metadata: hash size = " . scalar(keys %{$params->{metadata}}). ", tsv size = " . length($metadata_tsv) . "\n" if $debug;
-            if ($params->{metadata} and $metadata_tsv) {
-                my $metadata_file = "$tmpdir/$params->{output_file}_metadata.txt";
-                write_file($metadata_file, $metadata_tsv);
-                push @outputs, [$metadata_file, "tsv"];
-            }
-            my ($step_comments, $step_info) = start_step("Write PhyloXML");
-            my $tree = new Phylo_Tree($tree_file);
-            if ($params->{metadata}) {
-                $tree->add_bulk_properties($params->{metadata}, "BVBRC");
-            }
-            my $phyloxml_data = $tree->write_phyloXML($params->{metadata});
-            my $phyloxml_file = "$tmpdir/$params->{output_file}.xml";
-            write_file($phyloxml_file, $phyloxml_data);
-            push @outputs, [$phyloxml_file, "phyloxml"];
-            end_step("Write PhyloXML");
+        if (scalar @relabel_fields) {
+            print STDERR "Now write a tree with ids substituted with metadata fields: ", join(", ", @relabel_fields), "\n";
+            my $relabeled_newick_file = label_tree_with_metadata($tree_file, $metadata, \@relabel_fields);
+            push @outputs, [$relabeled_newick_file, 'nwk'];
         }
     }
     
-    my $html_file = "$tmpdir/$params->{output_file}_gene_tree_report.html";
-    write_report($html_file, $tree_graphic_file);
+    my $html_file = "$params->{output_file}_gene_tree_report.html";
+    write_report($html_file, $tree_graphic);
     push @outputs, [$html_file, "html"];
 
     print STDERR '\@outputs = '. Dumper(\@outputs);
@@ -502,33 +670,49 @@ sub build_tree {
             }
         }
     }
+    chdir($original_wd); # change back to the starting working directory
     my $time2 = `date`;
     write_output("Start: $time1"."End:   $time2", "$tmpdir/DONE");
 }
 
 sub gather_metadata {
-    my ($feature_metadata, $seq_ids_ar, $feature_fields, $genome_fields) = @_; 
+    my ($seq_items, $seqid_ar, $altered_names_hr, $feature_fields, $genome_fields) = @_; 
     my ($step_comments, $step_info) = start_step("Gather Metadata");
-    my $metadata_tsv = undef;
-    my $comment = "feature ids= $seq_ids_ar\n";
-    print STDERR $comment;
-    my $comment = "feature ids: ". join(", ", @{$seq_ids_ar});
+    my $comment = "feature ids: ". join(", ", @{$seqid_ar});
     push @{$step_comments}, $comment;
     print STDERR "$comment\n"; 
     $comment = "feature metadata fields: ". join(", ", @{$feature_fields});
     push @{$step_comments}, $comment;
     print STDERR "$comment\n"; 
-    my $comment = "in gather_metadata: feature ids= $seq_ids_ar\n";
+    my $comment = "in gather_metadata: feature ids= $seqid_ar\n";
     print STDERR $comment;
-    get_feature_metadata($feature_metadata, $seq_ids_ar, $feature_fields);
-    $comment = "number of features with data: " . scalar keys %{$feature_metadata};
+    if (exists $seq_items->[0]->{genome_metadata}) {
+        # case of aligning whole viral genomes, we already have the genome metadata, no features as such
+        print STDERR "Genome metadata in hand, reformat and return.\n" if $debug;
+        print STDERR "Genome fields: @$genome_fields\n";
+        my %genome_metadata;
+        for my $field (@$genome_fields) {
+            $genome_metadata{$field} = ();
+            print STDERR "\ngenmetrec[0] for $field: $seq_items->[0]->{genome_metadata}->[0]->{$field}\n";
+            for my $record (@{$seq_items->[0]->{genome_metadata}}) {
+                my $genome_id = $record->{genome_id};
+                $genome_metadata{$field}{$genome_id} = $record->{$field};
+                print STDERR "$field\t$genome_id\t$genome_metadata{$field}{$genome_id}\n";
+            }
+        }
+        end_step("Gather Metadata");
+        return \%genome_metadata;
+    }
+    my $feature_metadata = get_feature_metadata($seq_items, $seqid_ar, $altered_names_hr, $feature_fields);
+    #get_feature_metadata($feature_metadata, $seq_ids_ar, $feature_fields);
+    $comment = "number of feature metadata fields: " . scalar keys %{$feature_metadata};
     push @{$step_comments}, $comment;
     print STDERR "$comment\n"; 
     if ($feature_metadata and scalar keys %{$feature_metadata}) {
         my %genome_ids = ();
-        for my $feature_id (keys %{$feature_metadata}) {
-            if (exists $feature_metadata->{$feature_id}->{genome_id}) {
-                my $genome_id = $feature_metadata->{$feature_id}->{genome_id};
+        for my $feature_id (keys %{$feature_metadata->{genome_id}}) {
+            if (exists $feature_metadata->{genome_id}{$feature_id}) {
+                my $genome_id = $feature_metadata->{genome_id}{$feature_id};
                 $genome_ids{$genome_id} = 1;
             }
         }
@@ -539,56 +723,49 @@ sub gather_metadata {
         $comment = "genome metadata fields: ". join(", ", @{$genome_fields});
         push @{$step_comments}, $comment;
         print STDERR "$comment\n"; 
+        print STDERR "before merging genome_metadata, feature_metadata keys = \n", join(", ", keys %$feature_metadata), "\n";
+        my @tmp = keys %$feature_metadata;
+        print STDERR "tmp[0] = $tmp[0]\n";
+        print STDERR "for $tmp[0]: ", join(", ", keys %{$feature_metadata->{$tmp[0]}}), "\n";
 
-        my $genome_metadata = get_genome_metadata(\@genome_ids, $genome_fields);
-        for my $feature_id (keys %{$feature_metadata}) {
-            my $genome_id = $feature_metadata->{$feature_id}{genome_id};
-            if (exists $genome_metadata->{$genome_id}) {
-                #merge them
-                for my $key (keys %{$genome_metadata->{$genome_id}}) {
-                    if ($genome_metadata->{$genome_id}{$key}) {
-                        $feature_metadata->{$feature_id}{$key} = $genome_metadata->{$genome_id}{$key};
-                        print STDERR "mg $genome_id $key $feature_metadata->{$feature_id}->{$key}\n" if $debug;
-                    }
+        if (scalar @genome_ids) {
+            for my $genome_field (@$genome_fields) {
+                $feature_metadata->{$genome_field} = ();
+            }
+            my $genome_metadata = get_genome_metadata(\@genome_ids, $genome_fields);
+            for my $feature_id (keys %{$feature_metadata->{genome_id}}) {
+                my $genome_id = $feature_metadata->{genome_id}{$feature_id};
+                for my $genome_field (@$genome_fields) {
+                    my $value = $genome_metadata->{$genome_id}{$genome_field};
+                    $feature_metadata->{$genome_field}{$feature_id} = $value;
+                    print STDERR "gm $feature_id $genome_id $genome_field $value\n" if $debug;
                 }
-                #$feature_metadata->{$feature_id} = ($feature_metadata->{$feature_id}, $genome_metadata->{$genome_id}); 
             }
         }
-        my @fields = @{$feature_fields};
-        for my $genome_field (@{$genome_fields}) {
-            push(@fields, $genome_field) unless grep(/^$genome_field\$/, @fields);
-        }
-        $metadata_tsv = join("\t", "SeqId", @fields) . "\n";
-        for my $id (@{$seq_ids_ar}) {
-            $metadata_tsv .= $id;
-            for my $field (@fields) {
-                my $val = "na";
-                $val = $feature_metadata->{$id}{$field} if exists $feature_metadata->{$id}{$field};
-                $metadata_tsv .= "\t$val";
-            }
-            $metadata_tsv .= "\n";
-        }
-        $step_info->{details} = $metadata_tsv;
+        #my @fields = @{$feature_fields};
+        #for my $genome_field (@{$genome_fields}) {
+        #    push(@fields, $genome_field) unless grep(/^$genome_field\$/, @fields);
+        #}
     }
     end_step("Gather Metadata");
-    return $metadata_tsv;
+    return $feature_metadata;
 }
 
 sub trim_alignment {
-    my ($alignment, $params, $tmpdir) = @_;
+    my ($aligned_file, $trimmed_aligned_file, $trim_threshold, $gap_threshold) = @_;
     my ($trim_comments, $trim_info) = start_step("Trim Alignment");
-    my $comment = "performing trimming on alignment";
+    my $comment = "performing trimming on alignment: trim_threshod=$trim_threshold, gap_threhold=$gap_threshold";
     print STDERR "$comment\n";
     #push @{$trim_comments}, $comment;
-    #open my $ALIGNED, $aligned_file or die "could not open aligned fasta";
-    #my $alignment = new Sequence_Alignment($ALIGNED);
+    my $alignment = new Sequence_Alignment($aligned_file);
+    print STDERR "trim_alignment: alignment=$alignment\n";
     $trim_info->{details} = "Before trimming:\n" .  $alignment->write_stats();
     my $alignment_changed = 0;
-    if (exists $params->{trim_threshold} and $params->{trim_threshold} > 0) {
-        $comment = "trim ends of alignment to density " . $params->{trim_threshold};
+    if ($trim_threshold > 0) {
+        $comment = "trim ends of alignment to density $trim_threshold";
         print STDERR "$comment\n";
         push @{$trim_comments}, $comment;
-        my ($left_trim_cols, $right_trim_cols) = $alignment->end_trim($params->{trim_threshold});
+        my ($left_trim_cols, $right_trim_cols) = $alignment->end_trim($trim_threshold);
         if ($left_trim_cols or $right_trim_cols) {
             $comment = "ends trimmed: $left_trim_cols columns on left, $right_trim_cols columns on right.";
             print STDERR "$comment\n";
@@ -601,11 +778,11 @@ sub trim_alignment {
             print STDERR "$comment\n";
         }
     }
-    if (exists $params->{gap_threshold} and $params->{gap_threshold} > 0) {
-        $comment = "delete any sequences with gap proportion greater than ".$params->{gap_threshold};
+    if ($gap_threshold > 0) {
+        $comment = "delete any sequences with gap proportion greater than $gap_threshold";
         print STDERR "$comment\n";
         push @{$trim_comments}, $comment;
-        my $deleted_seqs = $alignment->delete_gappy_seqs($params->{gap_threshold});
+        my $deleted_seqs = $alignment->delete_gappy_seqs($gap_threshold);
         if (scalar @$deleted_seqs) {
             $comment = scalar(@$deleted_seqs) . " gappy sequences deleted: ". join(", ", @$deleted_seqs);
             print STDERR "$comment\n";
@@ -627,11 +804,14 @@ sub trim_alignment {
         push @{$trim_comments}, $comment;
         print STDERR "$comment\n";
     }
+    $alignment->write_fasta($trimmed_aligned_file);
+    $comment = "writing trimmed alignment to $trimmed_aligned_file\n";
+    print STDERR $comment;
     end_step("Trim Alignment");
 }
 
 sub run_raxml {
-    my ($alignment_file, $alphabet, $model, $output_name, $tmpdir) = @_;
+    my ($alignment_file, $alphabet, $model, $output_name) = @_;
     my ($step_comments, $step_info) = start_step("Phylogenetic Inference with RAxML");
     print STDERR "In run_raxml (with RELL support), alignment = $alignment_file\n";
     my $parallel = $ENV{P3_ALLOCATED_CPU};
@@ -659,7 +839,6 @@ sub run_raxml {
     push @{$step_comments}, $comment;
     print STDERR "$comment\n\n";
    
-    chdir($tmpdir); 
     my ($out, $err) = run_cmd(\@cmd);
     print STDERR "STDOUT:\n$out\n";
     print STDERR "STDERR:\n$err\n";
@@ -682,17 +861,16 @@ sub run_raxml {
     move("RAxML_info.".$output_name, $logFile);
     #my $details = read_file($logFile);
     #$step_info->{details} .= $details;
-    push @outputs, ["$tmpdir/$treeFile", 'nwk'];
-    push @outputs, ["$tmpdir/$logFile", 'txt'];
+    push @outputs, [$treeFile, 'nwk'];
+    push @outputs, [$logFile, 'txt'];
 
-    chdir($cwd);
-    run("echo $tmpdir && ls -ltr $tmpdir");
+    run("ls -ltr");
     end_step("Phylogenetic Inference with RAxML");
     return @outputs;
 }
 
 sub run_phyml {
-    my ($alignment_file, $alphabet, $model, $output_name, $tmpdir) = @_;
+    my ($alignment_file, $alphabet, $model, $output_name) = @_;
     my ($step_comments, $step_info) = start_step("Phylogenetic Inference with Phyml");
 
     my $cwd = getcwd();
@@ -715,7 +893,6 @@ sub run_phyml {
     push @{$step_comments}, $comment;
     print STDERR "$comment\n\n";
    
-    chdir($tmpdir); 
     my ($out, $err) = run_cmd(\@cmd);
     print STDERR "STDOUT:\n$out\n";
     print STDERR "STDERR:\n$err\n";
@@ -728,25 +905,22 @@ sub run_phyml {
     my $treeFile = $output_name."_phyml_tree.nwk";
     move($alignment_file."_phyml_tree.txt", $treeFile);
     my $logFile = $output_name."_phyml_log.txt";
-    move($alignment_file."_phyml_log.txt", $logFile);
+    move($alignment_file."_phyml_stats.txt", $logFile);
     my $details = read_file($logFile);
     $step_info->{details} .= $details;
-    push @outputs, ["$tmpdir/$treeFile", 'nwk'];
-    push @outputs, ["$tmpdir/$logFile", 'txt'];
+    push @outputs, [$treeFile, 'nwk'];
+    push @outputs, [$logFile, 'txt'];
 
-    chdir($cwd);
-    run("echo $tmpdir && ls -ltr $tmpdir");
+    run("ls -ltr");
 
     end_step("Phylogenetic Inference with Phyml");
     return @outputs;
 }
 
 sub run_fasttree {
-    my ($alignment_file, $alphabet, $model, $output_name, $tmpdir) = @_;
+    my ($alignment_file, $alphabet, $model, $output_name) = @_;
     my ($step_comments, $step_info) = start_step("Phylogenetic Inference with FastTree");
 
-    my $cwd = getcwd();
-    
     my $treeFile = $output_name."_fasttree.nwk";
     my @cmd = ("FastTree", "-out", $treeFile);
     if ($alphabet =~ /DNA/i) {
@@ -758,14 +932,11 @@ sub run_fasttree {
         push @cmd, "-$model";
     }
 
-    $alignment_file =~ s/.*\///; # strip off path as we will chdir to tmpdir
     push @cmd, $alignment_file;
     my $comment = join(" ", @cmd);
-    #$comment =~ s/$tmpdir//g;
     push @{$step_comments}, $comment; 
     print STDERR $comment . "\n\n";
    
-    chdir($tmpdir); 
     my ($out, $err) = run_cmd(\@cmd);
     print STDERR "STDOUT:\n$out\n";
     print STDERR "STDERR:\n$err\n";
@@ -775,11 +946,10 @@ sub run_fasttree {
     my @outputs;
     my $logFile = $output_name."_fasttree_log.txt";
     write_file($logFile, $err);
-    push @outputs, ["$tmpdir/$treeFile", 'nwk'];
-    push @outputs, ["$tmpdir/$logFile", 'txt'];
+    push @outputs, [$treeFile, 'nwk'];
+    push @outputs, [$logFile, 'txt'];
 
-    chdir($cwd);
-    run("echo $tmpdir && ls -ltr $tmpdir");
+    run("ls -ltr");
 
     end_step("Phylogenetic Inference with FastTree");
     return @outputs;
@@ -787,44 +957,118 @@ sub run_fasttree {
 
 sub get_feature_metadata {
     # add/supplement any data in feature_metadata hashref from patric feature id to hash of field values
-    my ($feature_metadata, $ids, $fields) = @_;
-    $fields = ['patric_id','genome_id','product'] unless $fields;
-    my $select_string = "select(" . join(",", @$fields) . ")"; 
-    my $escaped_ids = join(",", map { uri_escape $_ } @{$ids});
-    my $url = "$data_url/genome_feature/?in(patric_id,($escaped_ids))&$select_string";
-    print STDERR "query=$url\n";
-    my $resp = curl_json($url);
-    print STDERR "response=$resp\n";
-    if ( $resp =~ /Error/) {
-        warn "Problem! query did not return properly: $url\n";
-        return undef;
+    my ($seq_items, $seqid_ar, $altered_names_hr, $feature_fields) = @_;
+    $feature_fields = ['genome_id','product'] unless $feature_fields;
+    my %feature_metadata;
+    for my $field (@$feature_fields) {
+        $feature_metadata{$field} = (); # column major order
     }
-    #my %feature_metadata = ();
-    for my $member (@$resp) {
-        my $feature_id = $member->{patric_id};
-        $feature_metadata->{$feature_id} = $member;
+    my %seqs_with_data;
+    for my $seq_set (@$seq_items) {
+        if ($seq_set->{type} eq 'feature_group') {
+            for my $feature_data (@{$seq_set->{seq_list}}) {
+                my $seq_id = $feature_data->{patric_id};
+                next unless $seq_id;
+                for my $field (@$feature_fields) { # get just specified feature fields
+                    $feature_metadata{$field}{$seq_id} = $feature_data->{$field} if exists $feature_data->{$field};
+                }
+                $seqs_with_data{$seq_id} = 1;
+            }
+        }
     }
+
+    my @seqs_needing_data;
+    my %alt_name_rev;
+    for my $seq_id (@$seqid_ar) {
+        next if exists $seqs_with_data{$seq_id};
+        if (exists $altered_names_hr->{$seq_id}) {
+            my $alt_id = $altered_names_hr->{$seq_id}; 
+            $alt_name_rev{$alt_id} = $seq_id;
+            $seq_id = $alt_id;
+        }
+        push @seqs_needing_data, $seq_id;
+    }
+    if (scalar @seqs_needing_data) {
+        my $select_string = "select(" . join(",", @$feature_fields) . ")"; 
+        my $escaped_ids = join(",", map { uri_escape $_ } @seqs_needing_data);
+        my $url = "$data_url/genome_feature/?in(patric_id,($escaped_ids))&$select_string";
+        print STDERR "query=$url\n";
+        my $resp = curl_json($url);
+        print STDERR "response=$resp\n";
+        if ( $resp =~ /Error/) {
+            warn "Problem! query did not return properly: $url\n";
+            return undef;
+        }
+        print STDERR "length of resp = ", scalar(@$resp), "\n";
+        #***** need to fix this part
+        for my $member (@$resp) {
+            #my $feature_id = $member->{patric_id};
+            #$feature_metadata{$feature_id} = $member;
+            print STDERR " next member = $member\n";
+            my $seq_id = $member->{patric_id};
+            for my $field (@$feature_fields) {
+                $feature_metadata{$field}{$seq_id} = $member->{$field}
+            }
+        }
+    }
+    return \%feature_metadata;
 }
 
 sub get_genome_metadata {
     my ($genome_ids, $fields) = @_;
     print STDERR "in get_genome_metadata: genome ids = ", join(", ", @$genome_ids), "\n" if $debug;
-    $fields = ['genome_id','species'] unless $fields;
-    my $select_string = "select(" . join(",", @$fields) . ")"; 
+    return \() unless scalar(@$genome_ids);
+    $fields = ['species'] unless $fields;
+    my $select_string = "select(" . join(",", 'genome_id', @$fields) . ")"; 
     my $escaped_ids = join(",", @$genome_ids);
     my $url = "$data_url/genome/?in(genome_id,($escaped_ids))&$select_string";
     print STDERR "query=$url\n";
     my $resp = curl_json($url);
     my %genome_metadata = ();
     for my $member (@$resp) {
+        print STDERR "member: ", join(", ", sort(keys %$member)), "\n";
         my $genome_id = $member->{genome_id};
-        $genome_metadata{$genome_id} = $member;
+        for my $field (@$fields) {
+            $genome_metadata{$genome_id}{$field} = $member->{$field} unless $field eq 'genome_id';
+        }
     }
     return \%genome_metadata
 }
 
+sub label_tree_with_metadata {
+    my ($input_newick, $metadata, $label_fields) = @_;
+    my ($step_comments, $step_info) = start_step("Label Tree With Metadata");
+    my $comment = "label_tree_with_metadata called for fields: " . join(", ", @$label_fields);
+    for my $field (@$label_fields) {
+        print STDERR "metadata does not include $field\n" unless exists $metadata->{$field};
+    }
+    print STDERR $comment, "\n";
+    my $output_newick = $input_newick;
+    $output_newick =~ s/\..{2,6}$//; #remove extension
+    $output_newick .= "_relabeled_" . join("_", @$label_fields) . ".nwk";
+    my $newick = read_file($input_newick);
+    print STDERR "Got newick string: ", substr($newick, 0, 50), "\n";
+    my $start_field = $label_fields->[0];
+    for my $seq_id (keys %{$metadata->{$start_field}}) {
+        my @values = ();
+        for my $field (@$label_fields) {
+            push @values, $metadata->{$field}{$seq_id};
+        }
+        my $sub = join("|", @values);
+        $seq_id =~ s/\|/\\\|/g;
+        $sub =~ tr/[](),://d; #remove characters that break newick structure
+        $sub =~ tr/ /_/; #remove characters that break newick structure
+        print STDERR "substitute $seq_id with $sub\n";
+        $newick =~ s/$seq_id/$sub/;
+    }
+    print STDERR "Modified newick string: ", substr($newick, 0, 50), "\n";
+    write_file($output_newick, $newick);
+    end_step("Label Tree With Metadata");
+    return $output_newick;
+}
+
 sub generate_tree_graphic {
-    my ($input_newick, $num_tips, $tmpdir) = @_;
+    my ($input_newick, $num_tips) = @_;
     my ($step_comments, $step_info) = start_step("Generate Tree Graphic");
     my $file_base = basename($input_newick);
     $file_base =~ s/\..{2,6}//;
@@ -834,10 +1078,6 @@ sub generate_tree_graphic {
     #push @{$step_comments}, $comment;
     print STDERR "$comment\n";
 
-    my $cwd = getcwd();
-    chdir($tmpdir);
-    print STDERR "directory is now ", getcwd(), "\n";
-     
     open F, ">$nexus_file";
     print F "#NEXUS\nbegin trees;\n";
     my $tree_text = read_file($input_newick);
@@ -861,33 +1101,39 @@ sub generate_tree_graphic {
     }
     push @cmd, $nexus_file, $tree_graphic_file;
     $comment = join(" ", @cmd);
-    $comment =~ s/$tmpdir//g;
     push @{$step_comments}, $comment;
     print STDERR "$comment\n";
 
     my ($stdout, $stderr) =  run_cmd(\@cmd);
-    print STDERR "directory is now ", getcwd(), "\n";
-    chdir($cwd);
-    print STDERR "directory is now ", getcwd(), "\n";
     $step_info->{stdout} = $stdout;
     $step_info->{stderr} = $stderr;
     end_step("Generate Tree Graphic");
-    return "$tmpdir/$tree_graphic_file";
+    return [$tree_graphic_file, "svg"];
 }
 
 sub run_muscle {
-    my ($unaligned, $aligned, $tmpdir) = @_;
-    print STDERR "run_muscle($unaligned, $aligned, $tmpdir)\n";
-    my ($step_comments, $step_info) = start_step("Align Sequences");
+    my ($unaligned, $aligned) = @_;
+    print STDERR "run_muscle($unaligned, $aligned)\n";
+    my ($step_comments, $step_info) = start_step("Align with muscle");
     my $cmd = ["muscle", "-in", $unaligned, "-out", $aligned];
     my $comment = "command = " . join(" ", @$cmd);
-    if ($tmpdir) {
-        my $comment =~ s/$tmpdir//g;
-    }
     push @{$step_comments}, $comment;
     my ($stdout, $stderr) =  run_cmd($cmd);
     $step_info->{details} = $stderr;
-    end_step("Align Sequences");
+    end_step("Align with muscle");
+}
+
+sub run_mafft {
+    my ($unaligned, $aligned) = @_;
+    print STDERR "run_mafft($unaligned, $aligned)\n";
+    my ($step_comments, $step_info) = start_step("Align with mafft");
+    my $cmd = ["mafft", "--auto", $unaligned];
+    my $comment = "command = " . join("\t", @$cmd);
+    print STDERR "$comment\n";
+    my $out;
+    open $out, ">$aligned";
+    run($cmd, ">", $out);
+    end_step("Align with mafft");
 }
 
 sub curl_text {
@@ -940,31 +1186,32 @@ sub get_token {
 }
 
 sub get_ws_file {
-    my ($tmpdir, $id) = @_;
+    my ($id) = @_;
     # return $id; # testing
     my $ws = get_ws();
     my $token = get_token();
     
     my $base = basename($id);
-    my $file = "$tmpdir/$base";
+    my $file = $base;
     # return $file; # testing
+    print STDERR "get_ws_file:  base=$base, file=$file, ws=$ws, token=$token\n";
     
     my $fh;
     open($fh, ">", $file) or die "Cannot open $file for writing: $!";
 
-    print STDERR "GET WS => $tmpdir $base $id\n";
-    system("ls -la $tmpdir");
+    print STDERR "GET WS => $base $id\n";
+    system("ls -lrta ");
 
     eval {
 	$ws->copy_files_to_handles(1, $token, [[$id, $fh]]);
     };
     if ($@)
     {
-	die "ERROR getting file $id\n$@\n";
+        die "ERROR getting file $id\n$@\n";
     }
     close($fh);
     print "$id $file:\n";
-    system("ls -la $tmpdir");
+    system("ls -lrta ");
 
     return $file;
 }


### PR DESCRIPTION
Does not overwrite "$parameters".
Correct list of metadata fields is loaded.
Enables receiving a genome group of viruses and trees while viral genomes.
App spec changed to allow passing list of feature and genome metadata fields. 
Default metadata fields are used if none provided.
Code in place to use mafft for alignment, instead of muscle (future change could make user selectable).
