### PR TITLE
Fixed problem when genomes lack sequences.

### DIFF
--- a/scripts/p3x-concatenate-feature-alignments.pl
+++ b/scripts/p3x-concatenate-feature-alignments.pl
@@ -30,12 +30,17 @@ for my $family_file (@families) {
     while (<$f>) {
         if (/^>(\S+)/) {
             $feature = $1;
-            my $genome_id = 1;
+            my $genome_id = $1;
             if ($feature =~ /fig\|(\d+\.\d+)/ or $feature =~ /^(\d+\.\d+)$/ or /::(\d+\.\d+)/)
             {
                 $genome_id = $1;
             }
-            else { die "cannot parse genome_id from $feature"}
+            else {
+                />\S+\s+(\S+)/;
+                $feature = $genome_id . "_$1"; 
+                print "cannot parse genome_id, using $genome_id : $feature";
+                
+            }
             $genomes{$genome_id}++;
             $family_genome_count{$family}{$genome_id}++;
             push @{$family_genome_features{$family}{$genome_id}}, $feature;

--- a/service-scripts/App-GeneTree.pl
+++ b/service-scripts/App-GeneTree.pl
@@ -196,7 +196,7 @@ sub retrieve_sequence_data {
                     }
                     if (exists $master_seq_ids{$user_identifier}) {
                         while (exists $master_seq_ids{$user_identifier}) {
-                            $user_identifier .= "'"; # make unique by appending apostrophe
+                            $user_identifier .= "_d" # make unique by appending tag
                         }
                     }
                     $seq_item->{id} = $user_identifier;


### PR DESCRIPTION
Problem Richard Scheuerman had with failed jobs caused by some genomes lacking sequence data is handled. They are dropped from analysis and a list of such empty sequences is shown in HTML report.
I fixed up some aspects of the report - tailoring file name and title based on whether it is a GeneTree or VirusGenomeTree job. Tree graphic can be toggled visible/hidden.