### PR TITLE
Add workshop examples as test cases

### DIFF
--- a/tests/workshop_Amoxicillin_PBP2X.json
+++ b/tests/workshop_Amoxicillin_PBP2X.json
@@ -1,0 +1,24 @@
+{
+  "alphabet": "Protein",
+  "output_path": "/olson@patricbrc.org/PATRIC-QA/applications/App-GeneTree",
+  "sequences": [
+    {
+      "type": "feature_group",
+      "filename": "/olson@patricbrc.org/PATRIC-QA/applications/App-GeneTree/Private PBP2x"
+    },
+    {
+      "type": "feature_group",
+      "filename": "/olson@patricbrc.org/PATRIC-QA/applications/App-GeneTree/Amox_Sus_PBP2X"
+    },
+    {
+      "type": "feature_group",
+      "filename": "/olson@patricbrc.org/PATRIC-QA/applications/App-GeneTree/Res_Amox_PBP2X"
+    }
+  ],
+  "trim_threshold": "0",
+  "output_file": "workshop_amoxicillin_pbp2x",
+  "tree_type": "gene",
+  "gap_threshold": "0",
+  "substitution_model": "LG",
+  "recipe": "FastTree"
+}

--- a/tests/workshop_Cefotaxime_PBP2X.json
+++ b/tests/workshop_Cefotaxime_PBP2X.json
@@ -1,0 +1,20 @@
+{
+  "tree_type": "gene",
+  "trim_threshold": "0",
+  "output_file": "workshop_cefotaxime_pbp2x",
+  "sequences": [
+    {
+      "filename": "/olson@patricbrc.org/PATRIC-QA/applications/App-GeneTree/Cefotaxime resistant heatmap",
+      "type": "feature_group"
+    },
+    {
+      "filename": "/olson@patricbrc.org/PATRIC-QA/applications/App-GeneTree/Susceptible Pbp2x Cefotaxime",
+      "type": "feature_group"
+    }
+  ],
+  "output_path": "/olson@patricbrc.org/PATRIC-QA/applications/App-GeneTree",
+  "alphabet": "DNA",
+  "substitution_model": "GTR",
+  "gap_threshold": "0",
+  "recipe": "FastTree"
+}

--- a/tests/workshop_TetM_Amoxicillin.json
+++ b/tests/workshop_TetM_Amoxicillin.json
@@ -1,0 +1,20 @@
+{
+  "gap_threshold": "0",
+  "substitution_model": "LG",
+  "recipe": "FastTree",
+  "trim_threshold": "0",
+  "output_file": "workshop_tetm_amoxicillin",
+  "tree_type": "gene",
+  "alphabet": "Protein",
+  "sequences": [
+    {
+      "filename": "/olson@patricbrc.org/PATRIC-QA/applications/App-GeneTree/Sus TetM Amoxicillin",
+      "type": "feature_group"
+    },
+    {
+      "filename": "/olson@patricbrc.org/PATRIC-QA/applications/App-GeneTree/Res TetM Amox",
+      "type": "feature_group"
+    }
+  ],
+  "output_path": "/olson@patricbrc.org/PATRIC-QA/applications/App-GeneTree"
+}


### PR DESCRIPTION
  ## Summary
  - Adds 3 workshop QA test cases (PBP2X amoxicillin, PBP2X cefotaxime, and TetM amoxicillin gene trees) under tests/, pointed at the PATRIC-QA
  App-GeneTree workspace for input/output.
  - Note: the Cefotaxime_PBP2X test originally referenced a feature group ("Susceptible Cefotaxime Pbp2x") that doesn't exist; it was pointed at the
  existing group "Susceptible Pbp2x Cefotaxime" instead.
  
  ## Test plan
  - [x] Ran each test case via appserv-start-app against the app service; all completed successfully (job IDs 23062105, 23062106, 23062107).